### PR TITLE
add delayed_job_default_hooks settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ after 'deploy:published', 'delayed_job:restart' do
 end
 ```
 
+You can disable default hook by setting delayed_job_default_hooks to false
+```ruby
+set delayed_job_default_hooks, false
+```
+
 Following setting is recommended to avoid stop/restart problem.
 See [Issue #16](https://github.com/platanus/capistrano3-delayed-job/issues/16) or [PR #22](https://github.com/platanus/capistrano3-delayed-job/pull/22) for more detail.
 

--- a/lib/capistrano/tasks/delayed_job.rake
+++ b/lib/capistrano/tasks/delayed_job.rake
@@ -73,7 +73,7 @@ namespace :delayed_job do
   end
 
   after 'deploy:published', 'delayed_job:restart' do
-    invoke 'delayed_job:restart'
+    invoke 'delayed_job:restart' if fetch(:delayed_job_default_hooks)
   end
 
 end
@@ -86,5 +86,6 @@ namespace :load do
     set :delayed_job_roles, :app
     set :delayed_job_bin_path, 'bin'
     set :delayed_job_monitor, nil
+    set :delayed_job_default_hooks, true
   end
 end


### PR DESCRIPTION
Some times not need delayed_job default restart hook during deploy.