### PR TITLE
Support to set `--daemon-options` option for delayed_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ set :delayed_job_roles, [:app, :background]
 ### Set the location of the delayed_job pid file(s)
 # default value: "#{Rails.root}/tmp/pids" or "#{Dir.pwd}/tmp/pids"
 # set :delayed_job_pid_dir, 'path_to_pid_dir'
+
+### Set the options to be passed along to daemons when starting/stopping/restarting delayed_job workers
+# options supported by daemons can be found at https://github.com/thuehlinger/daemons/blob/master/lib/daemons/cmdline.rb
+# set :delayed_job_daemon_opts, ["no_wait", "shush"]
 ```
 
 It also conditionally adds the following hook:

--- a/lib/capistrano/tasks/delayed_job.rake
+++ b/lib/capistrano/tasks/delayed_job.rake
@@ -16,7 +16,7 @@ namespace :delayed_job do
       args << fetch(:delayed_job_pools, {}).map {|k,v| "--pool='#{k}:#{v}'" }.join(' ')
     end
     unless fetch(:delayed_job_daemon_opts).nil?
-      args << fetch(:delayed_job_daemon_opts, []).map { |option| "--daemon-options='--#{option}'"}.join(' ')
+      args << "--daemon-options='--#{fetch(:delayed_job_daemon_opts, []).join(',--')}'"
     end
     args.join(' ')
   end

--- a/lib/capistrano/tasks/delayed_job.rake
+++ b/lib/capistrano/tasks/delayed_job.rake
@@ -15,6 +15,9 @@ namespace :delayed_job do
     unless fetch(:delayed_job_pools).nil?
       args << fetch(:delayed_job_pools, {}).map {|k,v| "--pool='#{k}:#{v}'" }.join(' ')
     end
+    unless fetch(:delayed_job_daemon_opts).nil?
+      args << fetch(:delayed_job_daemon_opts, []).map { |option| "--daemon-options='--#{option}'"}.join(' ')
+    end
     args.join(' ')
   end
 


### PR DESCRIPTION
The release of `delayed_job` v4.1.3 added support to pass options to the `daemons` gem, https://github.com/collectiveidea/delayed_job/pull/916/files.

This adds support so those options can be specified in the Capistrano deploy configuration via 

```
set :delayed_job_daemon_opts, ["no_wait"]
```

Example output from running a Capistrano delayed_job task:
```
$ bundle exec cap staging delayed_job:restart
00:00 delayed_job:restart
      01 bundle exec bin/delayed_job --pool='default:5' --daemon-options='--no_wait' restart
...
```