### PR TITLE
add clear task

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ cap delayed_job:restart  # Restart the delayed_job process
 cap delayed_job:start    # Start the delayed_job process
 cap delayed_job:status   # Status of the delayed_job process
 cap delayed_job:stop     # Stop the delayed_job process
+cap delayed_job:clear    # Clear the delayed_job queue
 ```
 
 Configurable options (copy into deploy.rb), shown here with examples:

--- a/lib/capistrano/tasks/delayed_job.rake
+++ b/lib/capistrano/tasks/delayed_job.rake
@@ -86,6 +86,20 @@ namespace :delayed_job do
   if Rake::Task.task_defined?('deploy:published')
     after 'deploy:published', 'delayed_job:default'
   end
+
+  desc 'Clear existing jobs'
+  task :clear do
+    if fetch(:delayed_job_default_hooks)
+      on roles(delayed_job_roles) do
+        within release_path do
+          with rails_env: fetch(:rails_env) do
+            execute :rake, 'jobs:clear'
+          end
+        end
+      end
+    end
+  end
+
 end
 
 namespace :load do


### PR DESCRIPTION
Here is a patch that allows the user to either:

`cap <site> delayed_job:clear`

or add it to their deploy.rb like:

`before 'delayed_job:restart', 'delayed_job:clear'`

Especially helpful for dev/testing systems.

Hope this is of value.