### PR TITLE
Relax and update Daemons dependency

### DIFF
--- a/capistrano3-delayed-job.gemspec
+++ b/capistrano3-delayed-job.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'capistrano', '~> 3.0', '>= 3.0.0'
-  spec.add_dependency 'daemons', '~> 1.2.4'
+  spec.add_dependency 'daemons', '~> 1.3'
 
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rubocop", "~> 0.0", '>= 0.39.0'


### PR DESCRIPTION
Daemons follows Semantic Versioning, so it is safe to set the
dependency at its minor version number

Ref: thuehlinger/daemons#74

Please let me know if this gem is still maintained