### PR TITLE
Removes 'bundle exec from commands because it doesn't work with binstub.

### DIFF
--- a/lib/capistrano/tasks/delayed_job.rake
+++ b/lib/capistrano/tasks/delayed_job.rake
@@ -37,7 +37,7 @@ namespace :delayed_job do
     on roles(delayed_job_roles) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :bundle, :exec, delayed_job_bin, delayed_job_args, :stop
+          execute delayed_job_bin, delayed_job_args, :stop
         end
       end
     end
@@ -48,7 +48,7 @@ namespace :delayed_job do
     on roles(delayed_job_roles) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :bundle, :exec, delayed_job_bin, delayed_job_args, :start
+          execute delayed_job_bin, delayed_job_args, :start
         end
       end
     end
@@ -59,7 +59,7 @@ namespace :delayed_job do
     on roles(delayed_job_roles) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          capture( :bundle, :exec, delayed_job_bin, delayed_job_args, :status ).each_line do |line|
+          capture( delayed_job_bin, delayed_job_args, :status ).each_line do |line|
             info line
           end
         end
@@ -72,7 +72,7 @@ namespace :delayed_job do
     on roles(delayed_job_roles) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :bundle, :exec, delayed_job_bin, delayed_job_args, :restart
+          execute delayed_job_bin, delayed_job_args, :restart
         end
       end
     end


### PR DESCRIPTION
When using it with the delayed_job binstub and Bundler version 2, it fails with a
```sh
LoadError: cannot load such file -- bundler/setup
```
and bundler is already loaded in the binstub so this is unnecessary.